### PR TITLE
[Week 6 exercise 6] Mainly fixing autofill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 ## Tahtioppilaat
 [![GHA workflow Badge](https://github.com/PieniiSienii/tahtioppilaat/workflows/CI/badge.svg)](https://github.com/Pieniisienii/tahtioppilaat/actions)
+
 [![codecov](https://codecov.io/gh/PieniiSienii/tahtioppilaat/graph/badge.svg?token=0N8NYQEJWQ)](https://codecov.io/gh/PieniiSienii/tahtioppilaat)
 
 [Backlog linkki](https://docs.google.com/spreadsheets/d/1tfCgtgHHC6YhraJJi992deDDh6dO0IaimUXH1h2Ntps/edit?gid=0#gid=0)

--- a/src/app.py
+++ b/src/app.py
@@ -70,45 +70,47 @@ if test_env:
 
 @app.route("/delete_reference/<reference_type>/<int:reference_id>", methods=["POST"])
 def delete_reference(reference_type, reference_id):
-    if reference_type == "doi":
-        delete_doi(reference_id)
-    elif reference_type == "book":
-        delete_book(reference_id)
-    elif reference_type == "article":
-        delete_article(reference_id)
-    elif reference_type == "inproceeding":
-        delete_inproceeding(reference_id)
+    match reference_type:
+        case "doi":
+            delete_doi(reference_id)
+        case "book":
+            delete_book(reference_id)
+        case "article":
+            delete_article(reference_id)
+        case "inproceeding":
+            delete_inproceeding(reference_id)
     return redirect("/")
 
 @app.route("/edit_reference/<reference_type>/<int:reference_id>", methods=["POST"])
 def edit_reference(reference_type, reference_id):
-    if reference_type == "doi":
-        update_doi(reference_id, request.form.get("doi"))
-    elif reference_type == "book":
-        update_book(reference_id, {
-            "citation_key": request.form.get("book_citation_key"),
-            "author": request.form.get("book_author"),
-            "title": request.form.get("book_title"),
-            "book_title": request.form.get("book_book_title"),
-            "publisher": request.form.get("book_publisher"),
-            "year": request.form.get("book_year")
-        })
-    elif reference_type == "article":
-        update_article(reference_id, {
-            "citation_key": request.form.get("article_citation_key"),
-            "author": request.form.get("article_author"),
-            "title": request.form.get("article_title"),
-            "journal": request.form.get("article_journal"),
-            "year": request.form.get("article_year")
-        })
-    elif reference_type == "inproceeding":
-        update_inproceeding(reference_id, {
-            "citation_key": request.form.get("inproceeding_citation_key"),
-            "author": request.form.get("inproceeding_author"),
-            "title": request.form.get("inproceeding_title"),
-            "book_title": request.form.get("inproceeding_book_title"),
-            "year": request.form.get("inproceeding_year")
-        })
+    match reference_type:
+        case "doi":
+            update_doi(reference_id, request.form.get("doi"))
+        case "book":
+            update_book(reference_id, {
+                "citation_key": request.form.get("book_citation_key"),
+                "author": request.form.get("book_author"),
+                "title": request.form.get("book_title"),
+                "book_title": request.form.get("book_book_title"),
+                "publisher": request.form.get("book_publisher"),
+                "year": request.form.get("book_year")
+            })
+        case "article":
+            update_article(reference_id, {
+                "citation_key": request.form.get("article_citation_key"),
+                "author": request.form.get("article_author"),
+                "title": request.form.get("article_title"),
+                "journal": request.form.get("article_journal"),
+                "year": request.form.get("article_year")
+            })
+        case "inproceeding":
+            update_inproceeding(reference_id, {
+                "citation_key": request.form.get("inproceeding_citation_key"),
+                "author": request.form.get("inproceeding_author"),
+                "title": request.form.get("inproceeding_title"),
+                "book_title": request.form.get("inproceeding_book_title"),
+                "year": request.form.get("inproceeding_year")
+            })
     return redirect("/")
 
 

--- a/src/repositories/todo_repository.py
+++ b/src/repositories/todo_repository.py
@@ -74,7 +74,7 @@ def get_articles():
 
     # Map the results to Book objects
     return [Article(article[0], article[1], article[2],\
-                     article[3], article[4], article[4]) for article in articles]
+                     article[3], article[4], article[5]) for article in articles]
 
 
 def get_inproceedings():

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -248,9 +248,9 @@ My Bibliography Manager
               style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px; padding: 10px; border: 1px solid #ddd; border-radius: 4px;">
             <span>{{article}}</span>
             <div>
-              <button onclick="editReference('article', {{article.id}})" style="padding: 5px 10px; margin-right: 5px; background-color: #4CAF50; color: white; border: none; border-radius: 4px; cursor: pointer;">Edit</button>
-              <button onclick="deleteReference('article', {{article.id}})" style="padding: 5px 10px; background-color: #f44336; color: white; border: none; border-radius: 4px; cursor: pointer;">Delete</button>
-              <button onclick="viewBibTeX('article', {{article.id}})" style="padding: 5px 10px; background-color: #2196F3; color: white; border: none; border-radius: 4px; cursor: pointer;">BibTeX</button>
+              <button onclick="editReference('article', '{{article.id}}')" style="padding: 5px 10px; margin-right: 5px; background-color: #4CAF50; color: white; border: none; border-radius: 4px; cursor: pointer;">Edit</button>
+              <button onclick="deleteReference('article', '{{article.id}}')" style="padding: 5px 10px; background-color: #f44336; color: white; border: none; border-radius: 4px; cursor: pointer;">Delete</button>
+              <button onclick="viewBibTeX('article', '{{article.id}}')" style="padding: 5px 10px; background-color: #2196F3; color: white; border: none; border-radius: 4px; cursor: pointer;">BibTeX</button>
             </div>
           </li>
         {% endfor %}
@@ -265,9 +265,9 @@ My Bibliography Manager
               style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px; padding: 10px; border: 1px solid #ddd; border-radius: 4px;">
             <span>{{inproceeding}}</span>
             <div>
-              <button onclick="editReference('inproceeding', {{inproceeding.id}})" style="padding: 5px 10px; margin-right: 5px; background-color: #4CAF50; color: white; border: none; border-radius: 4px; cursor: pointer;">Edit</button>
-              <button onclick="deleteReference('inproceeding', {{inproceeding.id}})" style="padding: 5px 10px; background-color: #f44336; color: white; border: none; border-radius: 4px; cursor: pointer;">Delete</button>
-              <button onclick="viewBibTeX('inproceeding', {{inproceeding.id}})" style="padding: 5px 10px; background-color: #2196F3; color: white; border: none; border-radius: 4px; cursor: pointer;">BibTeX</button>
+              <button onclick="editReference('inproceeding', '{{inproceeding.id}}')" style="padding: 5px 10px; margin-right: 5px; background-color: #4CAF50; color: white; border: none; border-radius: 4px; cursor: pointer;">Edit</button>
+              <button onclick="deleteReference('inproceeding', '{{inproceeding.id}}')" style="padding: 5px 10px; background-color: #f44336; color: white; border: none; border-radius: 4px; cursor: pointer;">Delete</button>
+              <button onclick="viewBibTeX('inproceeding', '{{inproceeding.id}}')" style="padding: 5px 10px; background-color: #2196F3; color: white; border: none; border-radius: 4px; cursor: pointer;">BibTeX</button>
             </div>
           </li>
         {% endfor %}
@@ -281,9 +281,9 @@ My Bibliography Manager
               style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px; padding: 10px; border: 1px solid #ddd; border-radius: 4px;">
             <span>{{book}}</span>
             <div>
-              <button onclick="editReference('book', {{book.id}})" style="padding: 5px 10px; margin-right: 5px; background-color: #4CAF50; color: white; border: none; border-radius: 4px; cursor: pointer;">Edit</button>
-              <button onclick="deleteReference('book', {{book.id}})" style="padding: 5px 10px; background-color: #f44336; color: white; border: none; border-radius: 4px; cursor: pointer;">Delete</button>
-              <button onclick="viewBibTeX('book', {{book.id}})" style="padding: 5px 10px; background-color: #2196F3; color: white; border: none; border-radius: 4px; cursor: pointer;">BibTeX</button>
+              <button onclick="editReference('book', '{{book.id}}')" style="padding: 5px 10px; margin-right: 5px; background-color: #4CAF50; color: white; border: none; border-radius: 4px; cursor: pointer;">Edit</button>
+              <button onclick="deleteReference('book', '{{book.id}}')" style="padding: 5px 10px; background-color: #f44336; color: white; border: none; border-radius: 4px; cursor: pointer;">Delete</button>
+              <button onclick="viewBibTeX('book', '{{book.id}}')" style="padding: 5px 10px; background-color: #2196F3; color: white; border: none; border-radius: 4px; cursor: pointer;">BibTeX</button>
             </div>
           </li>
         {% endfor %}
@@ -297,9 +297,9 @@ My Bibliography Manager
               style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px; padding: 10px; border: 1px solid #ddd; border-radius: 4px;">
             <span>{{doi}}</span>
             <div>
-              <button onclick="editReference('doi', {{doi.id}})" style="padding: 5px 10px; margin-right: 5px; background-color: #4CAF50; color: white; border: none; border-radius: 4px; cursor: pointer;">Edit</button>
-              <button onclick="deleteReference('doi', {{doi.id}})" style="padding: 5px 10px; background-color: #f44336; color: white; border: none; border-radius: 4px; cursor: pointer;">Delete</button>
-              <button onclick="viewBibTeX('doi', {{doi.id}})" style="padding: 5px 10px; background-color: #2196F3; color: white; border: none; border-radius: 4px; cursor: pointer;">BibTeX</button>
+              <button onclick="editReference('doi', '{{doi.id}}')" style="padding: 5px 10px; margin-right: 5px; background-color: #4CAF50; color: white; border: none; border-radius: 4px; cursor: pointer;">Edit</button>
+              <button onclick="deleteReference('doi', '{{doi.id}}')" style="padding: 5px 10px; background-color: #f44336; color: white; border: none; border-radius: 4px; cursor: pointer;">Delete</button>
+              <button onclick="viewBibTeX('doi', '{{doi.id}}')" style="padding: 5px 10px; background-color: #2196F3; color: white; border: none; border-radius: 4px; cursor: pointer;">BibTeX</button>
             </div>
           </li>
         {% endfor %}

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -244,7 +244,10 @@ My Bibliography Manager
       <ul style="list-style: none; padding: 0;">
         {% for article in articles %}
           <li id="reference-article-{{article.id}}"
-              data-doi="{{article.article}}"
+              data-author="{{article.author}}"
+              data-title="{{article.title}}"
+              data-journal="{{article.journal}}"
+              data-year="{{article.year}}"
               style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px; padding: 10px; border: 1px solid #ddd; border-radius: 4px;">
             <span>{{article}}</span>
             <div>
@@ -261,7 +264,10 @@ My Bibliography Manager
       <ul style="list-style: none; padding: 0;">
         {% for inproceeding in inproceedings %}
           <li id="reference-inproceeding-{{inproceeding.id}}"
-              data-doi="{{inproceeding.inproceeding}}"
+            data-author="{{inproceeding.author}}"
+            data-title="{{inproceeding.title}}"
+            data-book-title="{{inproceeding.book_title}}"
+            data-year="{{inproceeding.year}}"
               style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px; padding: 10px; border: 1px solid #ddd; border-radius: 4px;">
             <span>{{inproceeding}}</span>
             <div>
@@ -277,7 +283,11 @@ My Bibliography Manager
       <ul style="list-style: none; padding: 0;">
         {% for book in books %}
           <li id="reference-book-{{book.id}}"
-              data-doi="{{book.book}}"
+            data-author="{{book.author}}"
+            data-title="{{book.title}}"
+            data-book-title="{{book.book_title}}"
+            data-publisher="{{book.publisher}}"
+            data-year="{{book.year}}"
               style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px; padding: 10px; border: 1px solid #ddd; border-radius: 4px;">
             <span>{{book}}</span>
             <div>


### PR DESCRIPTION
Pull request for week 6 exercise 6.

Contents:

- Fixed bugs shown in editor caused by missing parentheses in JS calls when passing Jinja variables as arguments
- Refactored couple long elif-clauses with match-case
- Slightly changed `index.html` to make the autofill work for citation types (other than DOI, which already worked)
- Changed one index in the return clause of `todo_repository`'s function `get_articles`, which caused the `year` field to retrieve incorrect value